### PR TITLE
fix(internal): fix cache for tensorflow.compat.v1

### DIFF
--- a/deepxde/utils/internal.py
+++ b/deepxde/utils/internal.py
@@ -36,7 +36,8 @@ def run_if_all_none(*attr):
             if all(i is None for i in x) or \
                 hasattr(self, "alpha") and \
                 bkd.is_tensor(self.alpha) and \
-                ((bkd.get_preferred_backend() == "paddle" and not self.alpha.stop_gradient) or (bkd.get_preferred_backend() != "paddle")):
+                ((bkd.get_preferred_backend() == "paddle" and not self.alpha.stop_gradient) or (
+                    bkd.get_preferred_backend() != "paddle" and bkd.get_preferred_backend() != "tensorflow.compat.v1")):
                 return func(self, *args, **kwargs)
             return x if len(x) > 1 else x[0]
 


### PR DESCRIPTION
1. 修复FPDE模型+可优化参数alpha组合的case下，后端使用tensorflow.compat.v1时，未执行cache导致模型运行速度过慢的问题