### PR TITLE
update import of LBFGS in backend 'paddle'

### DIFF
--- a/deepxde/optimizers/paddle/optimizers.py
+++ b/deepxde/optimizers/paddle/optimizers.py
@@ -1,13 +1,18 @@
 __all__ = ["get", "is_external_optimizer"]
 
 import paddle
-from paddle.incubate.optimizer import LBFGS
+from paddle.optimizer import LBFGS
 from ..config import LBFGS_options
 
+
 class InverseTimeDecay(paddle.optimizer.lr.InverseTimeDecay):
-    def __init__(self, learning_rate, gamma, decay_steps=1, last_epoch=-1, verbose=False):
+    def __init__(
+        self, learning_rate, gamma, decay_steps=1, last_epoch=-1, verbose=False
+    ):
         self.decay_steps = decay_steps
-        super(InverseTimeDecay, self).__init__(learning_rate, gamma, last_epoch, verbose)
+        super(InverseTimeDecay, self).__init__(
+            learning_rate, gamma, last_epoch, verbose
+        )
 
     def get_lr(self):
         return self.base_lr / (1 + self.gamma * (self.last_epoch / self.decay_steps))
@@ -18,10 +23,7 @@ def _get_lr_scheduler(lr, decay):
         return lr, None
     if decay[0] == "inverse time":
         lr_sch = InverseTimeDecay(
-            lr,  # 初始学习率
-            decay[2],  # 衰减系数
-            decay[1],  # 每隔decay[1]步衰减
-            verbose=False
+            lr, decay[2], decay[1], verbose=False  # 初始学习率  # 衰减系数  # 每隔decay[1]步衰减
         )
     else:
         raise NotImplementedError(
@@ -44,15 +46,15 @@ def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
             raise ValueError("L-BFGS optimizer doesn't support weight_decay > 0")
         if learning_rate is not None or decay is not None:
             print("Warning: learning rate is ignored for {}".format(optimizer))
-        
+
         optim = LBFGS(
-            lr=1,
+            learning_rate=1,
             max_iter=LBFGS_options["iter_per_step"],
             max_eval=LBFGS_options["fun_per_step"],
             tolerance_grad=LBFGS_options["gtol"],
             tolerance_change=LBFGS_options["ftol"],
             history_size=LBFGS_options["maxcor"],
-            line_search_fn='strong_wolfe',
+            line_search_fn="strong_wolfe",
             parameters=params,
         )
         return optim
@@ -65,5 +67,5 @@ def get(params, optimizer, learning_rate=None, decay=None, weight_decay=0):
 
         if optimizer == "adam":
             return paddle.optimizer.Adam(learning_rate=learning_rate, parameters=params)
-        
+
         raise NotImplementedError(f"{optimizer} to be implemented for backend Paddle.")


### PR DESCRIPTION
LBFGS moved from paddle.incubate.optimizer to paddle.optimizer in paddle develop version after 2023.4.27 and also in incoming paddle release 2.5 version. Modify import in code to adapt to it.
What is more, 'lr' param of LBFGS has been change to 'learning_rate' to keep consistent with other optimizers of paddle.